### PR TITLE
Not allow the user to create multiple tokens

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -110,11 +110,10 @@ export const signInUser = async (
     await User.findOneAndUpdate({ email }, { loggedIn: true });
 
     res.set("user-token", userToken);
-    res.json({
+    return res.status(200).json({
       success: true,
       message: `You have successfully logged in. Welcome ${user.name}`,
     });
-    next();
   } catch (error) {
     next(error);
   }

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -11,7 +11,7 @@ import {
   fromHexStringToUint8Array,
   finishDecipher,
 } from "../utils/encryption";
-import { ResourceNotFoundError } from "../errors";
+import { AuthenticationError, ResourceNotFoundError } from "../errors";
 
 export const registerUser = async (
   req: Request,
@@ -53,9 +53,26 @@ export const signInUser = async (
         name: 1,
         email: 1,
         password: 1,
+        loggedIn: 1,
       }
     );
-
+    console.log(`The current loggedin status is ${user?.loggedIn}`);
+    // const { expirationTime, currentTime } = await authenticate(req, res, next);
+    if (user && user.loggedIn == false) {
+      console.log("Your loggedIn status is false. Let me create a new token");
+    }
+    if (user && user.loggedIn == true) {
+      console.log(
+        "Your token has not expired yet and You are already logged in"
+      );
+      return res.json({
+        success: false,
+        message:
+          "Your token has not expired yet and You are already logged in.",
+        UserloggedinStatus: user.loggedIn,
+      });
+      //if the loggedin status is true, it will return res.json and end the code here instead of proceeding to the below code.
+    }
     if (!user)
       return res.json({
         success: false,
@@ -70,10 +87,11 @@ export const signInUser = async (
       });
     // the token should have information about created time, expiration time, user email (all encrypted)
     const session_rule = `{
-      created: ${Date.now()},
-      expiration: ${Date.now() + 3600000},
-      useremail: ${email},
+      "created": "${Date.now()}",
+      "expiration": "${Date.now() + 36000}",
+      "useremail": "${email}"
     }`;
+    //3600000
     let iv = Buffer.from(user.password.substring(32, 48));
     let now = Date.now();
     let secret = Buffer.from(user.password.substring(0, 19) + now.toString());
@@ -89,11 +107,14 @@ export const signInUser = async (
     encrypted = Buffer.concat([encrypted, cipher.final()]);
     const userToken =
       encrypted.toString("hex") + iv.toString("hex") + cipherText + cipherIv;
+    await User.findOneAndUpdate({ email }, { loggedIn: true });
+
     res.set("user-token", userToken);
     res.json({
       success: true,
       message: `You have successfully logged in. Welcome ${user.name}`,
     });
+    next();
   } catch (error) {
     next(error);
   }
@@ -104,6 +125,7 @@ export const authenticate = async (req: any, res: any, next: any) => {
     const userToken = req.headers["authorization"];
     const iv = Buffer.from(userToken.slice(-152, -120), "hex");
     const session_definition = userToken.slice(0, -152);
+
     const secretCipherText = hex2ArrayBuffer(userToken.slice(-120, -24));
     const secretIv = fromHexStringToUint8Array(userToken.slice(-24));
     const encryptedSecret = { cipherText: secretCipherText, iv: secretIv };
@@ -112,7 +134,29 @@ export const authenticate = async (req: any, res: any, next: any) => {
     const decipher = crypto.createDecipheriv("aes-256-cbc", secret, iv);
     let decrypted = decipher.update(textToDecipher);
     decrypted = Buffer.concat([decrypted, finishDecipher(decipher)]);
+    console.log(decrypted.toString());
+    console.log(JSON.parse(decrypted.toString()).expiration);
+    console.log(Date.now());
+    const jsonedSession = JSON.parse(decrypted.toString());
+    const expirationTime = jsonedSession.expiration;
+    const currentTime = Date.now();
+    if (currentTime > expirationTime) {
+      console.log(
+        "Your token has expired. Please sign in again. This message is from authenticate"
+      );
+      await User.findOneAndUpdate(
+        { email: jsonedSession.useremail },
+        { loggedIn: false }
+      );
+      throw new AuthenticationError(
+        "Your token has expired. Please sign in again"
+      );
+    }
 
+    // next();
+    console.log(
+      `Here is the expirationTime and currentTime ${expirationTime} ${currentTime}`
+    );
     next();
   } catch (error) {
     next(error);
@@ -126,7 +170,6 @@ export const getUsers = async (
 ) => {
   try {
     const users = await User.find({}).select({ password: false });
-    console.log(req.payload);
     res.send(users);
   } catch (error) {
     next(error);

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -5,6 +5,7 @@ export interface IUser {
   name: string;
   email: string;
   password: string;
+  loggedIn: boolean;
   // confirmpassword: string;
 }
 
@@ -16,6 +17,7 @@ const userSchema = new Schema<IUser>({
   name: { type: String, required: true },
   email: { type: String, required: true },
   password: { type: String, required: true },
+  loggedIn: { type: Boolean, required: true, default: false },
 });
 
 userSchema.set("toJSON", {


### PR DESCRIPTION
Added some code that does not allow the user to create multiple tokens. 
Possible future fix: 
Currently, loggedIn value only changes when Authenticate is executed. 
However, as you see in the below code:

------------------------------------------------------------------------
app.post("/users", validateUserSignUp, registerUser);
app.post("/sign-in", validateUserSignIn, signInUser);
app.use(authenticate);
app.get("/users", getUsers);
app.delete("/users/:userId", deleteUser);
app.get("/users/:userId", getUser);
app.put("/users/:userId", updateUser);
----------------------------------------------------------------------------
app.use(authenticate) is executed after app.post("sign-in"). Also loggedIn value is determined in app.use(authenticate). 
It means that even though we need the most recent loggedIn value in app.post(sign-in), we wouldn't  be able to know since the most recent loggedIn value is updated at  app.use(authenticate), which is execued after app.post(sign-in).

Currently, if you try to perform any of the executions that come after app.use (ex: app.get, app.delete, app.put), loggedIn value is updated (as app.use(authenticate) is executed) and tells if your token is expired (loggedIn=false) or not. If it is expired(loggedIn=false), you wouldn't be able to proceed and then you will be allowed to make another token at app.post(sign-in). If the token is not expired yet, anything that comes after app.use (ex: app.get, app.delete, app.put) can be executed but you won't be able to make a new token as loggedIn=true